### PR TITLE
ErrorHandler: Additional component information

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ class MyCompoenent extends React.PureComponent {
       try {
           return this.__originalRenderMethod__();
       } catch (e) {
-          return ReactSSRErrorHandler(e, this.constructor.name);
+          return ReactSSRErrorHandler(e, this.constructor.name, this);
       }
   }
 
@@ -72,12 +72,12 @@ npm install --save-dev @doochik/babel-plugin-transform-react-ssr-try-catch
 ### `errorHandler`
 
 Path to your errorHandler module.
-This is simple function with two arguments `(error, componentName)`
+This is simple function with three arguments `(error, componentName, componentContext)`
 
 ```js
 // SSRErrorHandler.js
 
-module.exports = (error, componentName) => {
+module.exports = (error, componentName, componentContext) => {
    // here you can log error and return fallback component or null.
 }
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ const createReactChecker = (t) => (node) => {
 };
 
 const getRenderMethodWithErrorHandler = (() => {
-    const tryCatchRender = `try{return this.__originalRenderMethod__();}catch(e){return ${ errorHandlerName }(e, this.constructor.name)}`;
+    const tryCatchRender = `try{return this.__originalRenderMethod__();}catch(e){return ${ errorHandlerName }(e, this.constructor.name, this)}`;
     let tryCatchRenderAST;
 
     return () => {

--- a/test/fixtures/errorHandler/component/expected.js
+++ b/test/fixtures/errorHandler/component/expected.js
@@ -9,7 +9,7 @@ class TestComponent extends Component {
     try {
       return this.__originalRenderMethod__();
     } catch (e) {
-      return ReactSSRErrorHandler(e, this.constructor.name);
+      return ReactSSRErrorHandler(e, this.constructor.name, this);
     }
   }
 

--- a/test/fixtures/errorHandler/purecomponent/expected.js
+++ b/test/fixtures/errorHandler/purecomponent/expected.js
@@ -9,7 +9,7 @@ class TestComponent extends PureComponent {
     try {
       return this.__originalRenderMethod__();
     } catch (e) {
-      return ReactSSRErrorHandler(e, this.constructor.name);
+      return ReactSSRErrorHandler(e, this.constructor.name, this);
     }
   }
 

--- a/test/fixtures/errorHandler/react-component/expected.js
+++ b/test/fixtures/errorHandler/react-component/expected.js
@@ -7,7 +7,7 @@ class TestComponent extends React.Component {
     try {
       return this.__originalRenderMethod__();
     } catch (e) {
-      return ReactSSRErrorHandler(e, this.constructor.name);
+      return ReactSSRErrorHandler(e, this.constructor.name, this);
     }
   }
 

--- a/test/fixtures/errorHandler/react-purecomponent/expected.js
+++ b/test/fixtures/errorHandler/react-purecomponent/expected.js
@@ -7,7 +7,7 @@ class TestComponent extends React.PureComponent {
     try {
       return this.__originalRenderMethod__();
     } catch (e) {
-      return ReactSSRErrorHandler(e, this.constructor.name);
+      return ReactSSRErrorHandler(e, this.constructor.name, this);
     }
   }
 

--- a/test/fixtures/errorHandler_and_errorRenderMethod/only-render/expected.js
+++ b/test/fixtures/errorHandler_and_errorRenderMethod/only-render/expected.js
@@ -7,7 +7,7 @@ class TestComponent extends React.PureComponent {
     try {
       return this.__originalRenderMethod__();
     } catch (e) {
-      return ReactSSRErrorHandler(e, this.constructor.name);
+      return ReactSSRErrorHandler(e, this.constructor.name, this);
     }
   }
 


### PR DESCRIPTION
**Fixes** #6
Currently, the errorHandler function takes in the error object and componentName as arguments. It would be good to have some more context for the component that errors. This additional information(say props) could for instance, be used in either logging, or in the fallback component. 

**Changes**: I have made the below changes to be backward compatible, technically we won't need `this.constructor.name` passed in, if we were to pass just `this`.
```
// Before
const getRenderMethodWithErrorHandler = (() => {
    const tryCatchRender = `try{return this.__originalRenderMethod__();}catch(e){return ${ errorHandlerName }(e, this.constructor.name)}`;
    let tryCatchRenderAST;

    return () => {
        if (!tryCatchRenderAST) {
            tryCatchRenderAST = babelParser.parse(tryCatchRender, {allowReturnOutsideFunction: true}).program.body[0];
        }

        return tryCatchRenderAST;
    };
})();

// After
const getRenderMethodWithErrorHandler = (() => {
    const tryCatchRender = `try{return this.__originalRenderMethod__();}catch(e){return ${ errorHandlerName }(e, this.constructor.name, this)}`;
    let tryCatchRenderAST;

    return () => {
        if (!tryCatchRenderAST) {
            tryCatchRenderAST = babelParser.parse(tryCatchRender, {allowReturnOutsideFunction: true}).program.body[0];
        }

        return tryCatchRenderAST;
    };
})();
```

This could be extended to the errorRenderMethod as well. Happy to raise a separate PR for it.